### PR TITLE
Update theme colors to ChatGPT style

### DIFF
--- a/COLOR_MIGRATION_GUIDE.md
+++ b/COLOR_MIGRATION_GUIDE.md
@@ -7,7 +7,7 @@ This guide documents the migration from the original colorful theme to the new p
 ### Primary Colors
 | Old | New | Usage |
 |-----|-----|-------|
-| `sunbeamGold` (#F7C548) | `electricBlue` (#3B82F6) | Primary actions, CTAs |
+| `sunbeamGold` (#F7C548) | `accentGreen` (#10A37F) | Primary actions, CTAs |
 | `glassGreen` (#7FB069) | `deepNavy` (#0F172A) | Headers, primary brand |
 | `skyBlue` (#87CEEB) | `slateGray` (#475569) | Secondary elements |
 
@@ -83,7 +83,7 @@ For remaining screens, use these patterns:
 ### Color References
 ```typescript
 // Old → New
-theme.colors.primary.sunbeamGold → theme.colors.primary.electricBlue
+theme.colors.primary.sunbeamGold → theme.colors.primary.accentGreen
 theme.colors.primary.glassGreen → theme.colors.primary.deepNavy
 theme.colors.primary.skyBlue → theme.colors.primary.slateGray
 theme.colors.light.background → theme.colors.background.pureWhite

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -52,7 +52,7 @@ const Button: React.FC<ButtonProps> = ({
         return theme.colors.text.white;
       case 'secondary':
       case 'outline':
-        return theme.colors.primary.electricBlue;
+        return theme.colors.primary.accentGreen;
       case 'ghost':
         return theme.colors.primary.slateGray;
       default:
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
   
   // Variants - Updated for professional design
   primary: {
-    backgroundColor: theme.colors.primary.electricBlue,
+    backgroundColor: theme.colors.primary.accentGreen,
     ...theme.shadows.card,
   },
   secondary: {
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
   outline: {
     backgroundColor: 'transparent',
     borderWidth: 2,
-    borderColor: theme.colors.primary.electricBlue,
+    borderColor: theme.colors.primary.accentGreen,
   },
   
   // Sizes
@@ -136,13 +136,13 @@ const styles = StyleSheet.create({
     color: theme.colors.text.white,
   },
   secondaryText: {
-    color: theme.colors.primary.electricBlue,
+    color: theme.colors.primary.accentGreen,
   },
   ghostText: {
     color: theme.colors.primary.slateGray,
   },
   outlineText: {
-    color: theme.colors.primary.electricBlue,
+    color: theme.colors.primary.accentGreen,
   },
   disabledText: {
     opacity: 0.7,

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
     ...theme.shadows.card,
   },
   primary: {
-    backgroundColor: theme.colors.primary.electricBlue,
+    backgroundColor: theme.colors.primary.accentGreen,
   },
   secondary: {
     backgroundColor: theme.colors.primary.deepNavy,

--- a/src/components/ProfilePicture.tsx
+++ b/src/components/ProfilePicture.tsx
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   placeholder: {
-    backgroundColor: theme.colors.primary.electricBlue,
+    backgroundColor: theme.colors.primary.accentGreen,
   },
   initials: {
     color: theme.colors.background.pureWhite,

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
   },
   outlined: {
     backgroundColor: 'transparent',
-    borderColor: theme.colors.primary.electricBlue,
+    borderColor: theme.colors.primary.accentGreen,
     borderWidth: 2,
   },
   error: {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -163,7 +163,7 @@ const BottomTabNavigator = () => (
         height: 88,
         ...theme.shadows.card,
       },
-      tabBarActiveTintColor: theme.colors.primary.electricBlue,
+      tabBarActiveTintColor: theme.colors.primary.accentGreen,
       tabBarInactiveTintColor: theme.colors.text.mediumGray,
       tabBarLabelStyle: {
         fontSize: 12,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -137,7 +137,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
               <MaterialIcons 
                 name="lightbulb" 
                 size={24} 
-                color={theme.colors.primary.electricBlue} 
+                color={theme.colors.primary.accentGreen} 
               />
             </View>
             <View style={styles.tipContent}>
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
   quickCreateButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: theme.colors.primary.electricBlue,
+    backgroundColor: theme.colors.primary.accentGreen,
     paddingVertical: theme.spacing.lg,
     paddingHorizontal: theme.spacing['2xl'],
     borderRadius: theme.borderRadius.xl,

--- a/src/screens/MatchScreen.tsx
+++ b/src/screens/MatchScreen.tsx
@@ -507,7 +507,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,
-    borderColor: theme.colors.primary.electricBlue,
+    borderColor: theme.colors.primary.accentGreen,
     elevation: 2,
   },
   scoreDisplayTablet: {
@@ -518,7 +518,7 @@ const styles = StyleSheet.create({
   },
   scoreText: {
     ...theme.textStyles.h1,
-    color: theme.colors.primary.electricBlue,
+    color: theme.colors.primary.accentGreen,
     fontWeight: 'bold',
     textAlign: 'center',
     lineHeight: theme.textStyles.h1.fontSize * 1.1,

--- a/src/screens/PlayersScreen.tsx
+++ b/src/screens/PlayersScreen.tsx
@@ -137,7 +137,7 @@ const PlayersScreen: React.FC<Props> = ({ navigation }) => {
   const renderGenderLabel = (gender: string) => {
     const isMale = gender.toLowerCase() === 'male';
     const iconName = isMale ? 'human-male' : 'human-female';
-    const iconColor = isMale ? theme.colors.primary.electricBlue : '#E91E63';
+    const iconColor = isMale ? theme.colors.primary.accentGreen : '#E91E63';
     
     return (
       <View style={styles.genderContainer}>
@@ -255,7 +255,7 @@ const PlayersScreen: React.FC<Props> = ({ navigation }) => {
         <View style={styles.loadingContainer}>
           <ActivityIndicator 
             size="large" 
-            color={theme.colors.primary.electricBlue} 
+            color={theme.colors.primary.accentGreen} 
           />
           <Text style={styles.loadingText}>
             {fixingStats ? 'Resetting player statistics...' : 'Loading players...'}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,24 +1,24 @@
 export const colors = {
-  // Core Brand Colors (New Professional Scheme)
+  // Core Brand Colors (ChatGPT inspired)
   primary: {
-    deepNavy: '#0F172A',        // Primary brand, headers
-    electricBlue: '#3B82F6',    // Primary actions, CTAs
-    slateGray: '#475569',       // Secondary elements
+    deepNavy: '#202123',        // Dark header/background
+    accentGreen: '#10A37F',     // Accent actions
+    slateGray: '#40414F',       // Secondary elements
   },
   
   // Background Colors
   background: {
     pureWhite: '#FFFFFF',       // Main background
-    coolGray: '#F8FAFC',        // Card backgrounds
-    lightGray: '#F1F5F9',       // Section dividers
+    coolGray: '#F7F7F8',        // Card backgrounds
+    lightGray: '#E5E5EA',       // Section dividers
   },
   
   // Text Colors
   text: {
-    richBlack: '#0F172A',       // Primary text
-    darkGray: '#334155',        // Secondary text
-    mediumGray: '#64748B',      // Placeholder text
-    lightGray: '#94A3B8',       // Disabled text
+    richBlack: '#202123',       // Primary text
+    darkGray: '#40414F',        // Secondary text
+    mediumGray: '#6B7280',      // Placeholder text
+    lightGray: '#9CA3AF',       // Disabled text
     white: '#FFFFFF',           // White text for dark backgrounds
   },
   
@@ -41,49 +41,49 @@ export const colors = {
     charcoal: '#3A3A37',
   },
   
-  // Light mode theme (Updated to professional scheme)
+  // Light mode theme (ChatGPT inspired)
   light: {
     background: '#FFFFFF',
     surface: '#FFFFFF',
-    card: '#F8FAFC',
+    card: '#F7F7F8',
     text: {
-      primary: '#0F172A',
-      secondary: '#334155',
-      tertiary: '#64748B',
-      disabled: '#94A3B8',
+      primary: '#202123',
+      secondary: '#40414F',
+      tertiary: '#6B7280',
+      disabled: '#9CA3AF',
       inverse: '#FFFFFF',
     },
-    border: '#F1F5F9',
-    notification: '#3B82F6',
-    primary: '#3B82F6',
-    secondary: '#475569',
+    border: '#E5E5EA',
+    notification: '#10A37F',
+    primary: '#10A37F',
+    secondary: '#40414F',
   },
   
-  // Dark mode theme (Updated for consistency)
+  // Dark mode theme (ChatGPT inspired)
   dark: {
-    background: '#0F172A',
-    surface: '#1E293B',
-    card: '#334155',
+    background: '#343541',
+    surface: '#202123',
+    card: '#40414F',
     text: {
-      primary: '#FFFFFF',
-      secondary: '#CBD5E1',
-      tertiary: '#94A3B8',
-      disabled: '#64748B',
-      inverse: '#0F172A',
+      primary: '#ECECF1',
+      secondary: '#C5C5D2',
+      tertiary: '#9CA3AF',
+      disabled: '#6B7280',
+      inverse: '#202123',
     },
-    border: '#475569',
-    notification: '#3B82F6',
-    primary: '#3B82F6',
-    secondary: '#CBD5E1',
+    border: '#565869',
+    notification: '#10A37F',
+    primary: '#10A37F',
+    secondary: '#ECECF1',
   },
 } as const;
 
 export const gradients = {
-  // Updated gradients for professional look
-  primaryBlue: ['#3B82F6', '#2563EB'],
-  navy: ['#0F172A', '#1E293B'],
-  navyGradient: ['#0F172A', '#1E293B', '#334155'], // Beautiful navy fade down gradient
-  coolGray: ['#F8FAFC', '#F1F5F9'],
+  // Gradients inspired by ChatGPT palette
+  primaryGreen: ['#10A37F', '#19C37D'],
+  navy: ['#343541', '#202123'],
+  navyGradient: ['#343541', '#40414F', '#202123'],
+  coolGray: ['#F7F7F8', '#E5E5EA'],
   
   // Legacy gradients (for backward compatibility)
   sunbeam: ['#F7C548', '#E6B439'],

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -24,7 +24,7 @@ export const theme = {
     },
     button: {
       primary: {
-        backgroundColor: colors.primary.electricBlue,
+        backgroundColor: colors.primary.accentGreen,
         borderRadius: borderRadius.lg,
         height: dimensions.buttonHeight.md,
         paddingHorizontal: spacing.xl,
@@ -48,7 +48,7 @@ export const theme = {
       outline: {
         backgroundColor: 'transparent',
         borderWidth: 2,
-        borderColor: colors.primary.electricBlue,
+        borderColor: colors.primary.accentGreen,
         borderRadius: borderRadius.lg,
         height: dimensions.buttonHeight.md,
         paddingHorizontal: spacing.xl,


### PR DESCRIPTION
## Summary
- refresh primary color palette to ChatGPT-inspired greens and dark grays
- update light and dark theme shades to match the ChatGPT look
- revise gradient definitions for the new scheme
- rename `electricBlue` to `accentGreen`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f768892548327b042fde28e4b40b5