### PR TITLE
Apply ChatGPT aesthetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tournament Maker
 
 A React Native mobile app for managing camping group tournaments with team-based competitions.
+The interface now features a ChatGPT-inspired dark theme with green accents.
 
 ## Features
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -45,7 +45,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
         
         {/* Hero Header with Gradient */}
         <LinearGradient
-          colors={['#0F172A', '#1E293B', '#334155']}
+          colors={['#202123', '#343541', '#444654']}
           style={styles.heroSection}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}>

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -1,38 +1,32 @@
-# Solarium Theme System
+# ChatGPT Theme System
 
-This theme system implements a solarium-inspired design that captures the essence of natural light, warmth, and botanical elements typically found in sunrooms and solariums.
+This theme system implements a ChatGPT‑inspired aesthetic with deep grays and a vibrant green accent.
 
 ## Design Principles
 
-1. **Natural Light**: Uses warm whites and soft yellows to mimic natural sunlight
-2. **Botanical Elements**: Incorporates greens and earth tones for a garden-like feel
-3. **Transparency**: Uses subtle opacity variations to suggest glass and openness
-4. **Warmth**: Favors warm tones over cool ones to create an inviting atmosphere
-5. **High Contrast**: Ensures accessibility with proper contrast ratios
+1. **Dark Mode First**: Rich gray backgrounds for a modern look
+2. **Vibrant Accent**: ChatGPT green for primary actions
+3. **Minimalist**: Clean surfaces with subtle shadows
+4. **Accessibility**: High contrast ratios for readability
+5. **Consistency**: Unified palette across components
 
 ## Color Palette
 
 ### Primary Colors
-- **Sunbeam Gold** (`#F7C548`) - Primary actions, highlights
-- **Glass Green** (`#7FB069`) - Secondary actions, success states
-- **Sky Blue** (`#87CEEB`) - Links, interactive elements
+- **ChatGPT Green** (`#10A37F`) - Primary actions
+- **Deep Gray** (`#343541`) - Main background
+- **Card Gray** (`#444654`) - Card surfaces
 
 ### Neutral Colors
-- **Warm White** (`#FDFBF7`) - Backgrounds, cards
-- **Soft Gray** (`#E8E5E0`) - Borders, dividers
-- **Stone Gray** (`#9B9B93`) - Secondary text
-- **Charcoal** (`#3A3A37`) - Primary text
+- **Off White** (`#ECECF1`) - Text and icons
+- **Border Gray** (`#E5E5E5`) - Dividers
+- **Dark Slate** (`#202123`) - Headers
 
 ### Accent Colors
-- **Terracotta** (`#D17B47`) - Warnings, attention
-- **Lavender Mist** (`#E6E0F3`) - Subtle highlights
-- **Sage** (`#A8C09A`) - Alternative success
-
-### Semantic Colors
-- **Success Green** (`#52B788`) - Success messages
-- **Warning Amber** (`#F4A261`) - Warning states
-- **Error Coral** (`#E76F51`) - Error messages
-- **Info Blue** (`#6FAADB`) - Information alerts
+- **Success Green** (`#10A37F`) - Success states
+- **Warning Orange** (`#F59E0B`) - Warnings
+- **Error Red** (`#EF4444`) - Errors
+- **Info Blue** (`#0EA5E9`) - Information
 
 ## Components
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,24 +1,24 @@
 export const colors = {
-  // Core Brand Colors (New Professional Scheme)
+  // Core Brand Colors (ChatGPT Aesthetic)
   primary: {
-    deepNavy: '#0F172A',        // Primary brand, headers
-    electricBlue: '#3B82F6',    // Primary actions, CTAs
-    slateGray: '#475569',       // Secondary elements
+    deepNavy: '#202123',        // Primary brand, headers
+    electricBlue: '#10A37F',    // Primary actions, CTAs
+    slateGray: '#40414F',       // Secondary elements
   },
   
   // Background Colors
   background: {
-    pureWhite: '#FFFFFF',       // Main background
-    coolGray: '#F8FAFC',        // Card backgrounds
-    lightGray: '#F1F5F9',       // Section dividers
+    pureWhite: '#343541',       // Main background
+    coolGray: '#444654',        // Card backgrounds
+    lightGray: '#202123',       // Section dividers
   },
   
   // Text Colors
   text: {
-    richBlack: '#0F172A',       // Primary text
-    darkGray: '#334155',        // Secondary text
-    mediumGray: '#64748B',      // Placeholder text
-    lightGray: '#94A3B8',       // Disabled text
+    richBlack: '#ECECF1',       // Primary text
+    darkGray: '#C5C5D2',        // Secondary text
+    mediumGray: '#8E8EA0',      // Placeholder text
+    lightGray: '#6B6B7B',       // Disabled text
     white: '#FFFFFF',           // White text for dark backgrounds
   },
   
@@ -41,49 +41,49 @@ export const colors = {
     charcoal: '#3A3A37',
   },
   
-  // Light mode theme (Updated to professional scheme)
+  // Light mode theme (ChatGPT style)
   light: {
     background: '#FFFFFF',
     surface: '#FFFFFF',
-    card: '#F8FAFC',
+    card: '#F7F7F8',
     text: {
-      primary: '#0F172A',
-      secondary: '#334155',
-      tertiary: '#64748B',
-      disabled: '#94A3B8',
+      primary: '#202123',
+      secondary: '#40414F',
+      tertiary: '#6B6B7B',
+      disabled: '#8E8EA0',
       inverse: '#FFFFFF',
     },
-    border: '#F1F5F9',
-    notification: '#3B82F6',
-    primary: '#3B82F6',
-    secondary: '#475569',
+    border: '#E5E5E5',
+    notification: '#10A37F',
+    primary: '#10A37F',
+    secondary: '#40414F',
   },
   
-  // Dark mode theme (Updated for consistency)
+  // Dark mode theme (ChatGPT style)
   dark: {
-    background: '#0F172A',
-    surface: '#1E293B',
-    card: '#334155',
+    background: '#343541',
+    surface: '#202123',
+    card: '#444654',
     text: {
-      primary: '#FFFFFF',
-      secondary: '#CBD5E1',
-      tertiary: '#94A3B8',
-      disabled: '#64748B',
-      inverse: '#0F172A',
+      primary: '#ECECF1',
+      secondary: '#C5C5D2',
+      tertiary: '#8E8EA0',
+      disabled: '#6B6B7B',
+      inverse: '#202123',
     },
-    border: '#475569',
-    notification: '#3B82F6',
-    primary: '#3B82F6',
-    secondary: '#CBD5E1',
+    border: '#40414F',
+    notification: '#10A37F',
+    primary: '#10A37F',
+    secondary: '#C5C5D2',
   },
 } as const;
 
 export const gradients = {
-  // Updated gradients for professional look
-  primaryBlue: ['#3B82F6', '#2563EB'],
-  navy: ['#0F172A', '#1E293B'],
-  navyGradient: ['#0F172A', '#1E293B', '#334155'], // Beautiful navy fade down gradient
-  coolGray: ['#F8FAFC', '#F1F5F9'],
+  // Updated gradients for ChatGPT look
+  primaryBlue: ['#10A37F', '#0E8F6E'],
+  navy: ['#202123', '#343541'],
+  navyGradient: ['#202123', '#343541', '#444654'], // Deep gray gradient
+  coolGray: ['#343541', '#444654'],
   
   // Legacy gradients (for backward compatibility)
   sunbeam: ['#F7C548', '#E6B439'],


### PR DESCRIPTION
## Summary
- integrate ChatGPT-inspired color palette
- update home screen gradient
- document new theme
- mention dark theme in project README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408caecad48327a807c206d0780e7a