### PR TITLE
Apply theme system across screens

### DIFF
--- a/src/screens/CreatePlayerGroupScreen.tsx
+++ b/src/screens/CreatePlayerGroupScreen.tsx
@@ -14,6 +14,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
 import { RootStackParamList, PlayerGroup, Player, SerializedPlayerGroup } from '../types';
 import DatabaseService from '../services/DatabaseService';
+import { theme } from '../theme';
 
 type CreatePlayerGroupScreenNavigationProp = StackNavigationProp<RootStackParamList, 'CreatePlayerGroup'>;
 type CreatePlayerGroupScreenRouteProp = RouteProp<RootStackParamList, 'CreatePlayerGroup'>;
@@ -244,13 +245,13 @@ const CreatePlayerGroupScreen: React.FC<Props> = ({ navigation, route }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   scrollView: {
     flex: 1,
   },
   section: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     margin: 16,
     padding: 16,
     borderRadius: 12,
@@ -258,30 +259,30 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 12,
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   playerCard: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     marginBottom: 8,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   playerCardSelected: {
-    backgroundColor: '#e8f5e8',
-    borderColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
+    borderColor: theme.colors.accent.successGreen,
   },
   playerInfo: {
     flex: 1,
@@ -289,28 +290,28 @@ const styles = StyleSheet.create({
   playerName: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 2,
   },
   playerNameSelected: {
-    color: '#2E7D32',
+    color: theme.colors.accent.successGreen,
   },
   playerNickname: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     fontStyle: 'italic',
     marginBottom: 2,
   },
   playerNicknameSelected: {
-    color: '#388E3C',
+    color: theme.colors.accent.successGreen,
   },
   playerGender: {
     fontSize: 12,
-    color: '#999',
+    color: theme.colors.text.mediumGray,
     textTransform: 'capitalize',
   },
   playerGenderSelected: {
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
   },
   selectionIndicator: {
     width: 24,
@@ -320,7 +321,7 @@ const styles = StyleSheet.create({
   },
   checkmark: {
     fontSize: 18,
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
     fontWeight: 'bold',
   },
   emptyState: {
@@ -329,18 +330,18 @@ const styles = StyleSheet.create({
   },
   emptyStateText: {
     fontSize: 16,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     textAlign: 'center',
     marginBottom: 16,
   },
   addPlayersButton: {
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
   },
   addPlayersButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
   },
   buttonContainer: {
@@ -348,27 +349,27 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   saveButton: {
-    backgroundColor: '#FF9800',
+    backgroundColor: theme.colors.accent.warningOrange,
     padding: 16,
     borderRadius: 8,
     alignItems: 'center',
   },
   saveButtonDisabled: {
-    backgroundColor: '#ccc',
+    backgroundColor: theme.colors.text.lightGray,
   },
   saveButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },
   deleteButton: {
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     padding: 16,
     borderRadius: 8,
     alignItems: 'center',
   },
   deleteButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },

--- a/src/screens/CreatePlayerScreen.tsx
+++ b/src/screens/CreatePlayerScreen.tsx
@@ -18,6 +18,7 @@ import { RootStackParamList, Gender, Player } from '../types';
 import DatabaseService from '../services/DatabaseService';
 import ImageService from '../services/ImageService';
 import ProfilePicture from '../components/ProfilePicture';
+import { theme } from '../theme';
 
 type CreatePlayerScreenNavigationProp = StackNavigationProp<RootStackParamList, 'CreatePlayer'>;
 type CreatePlayerScreenRouteProp = RouteProp<RootStackParamList, 'CreatePlayer'>;
@@ -336,7 +337,7 @@ const CreatePlayerScreen: React.FC<Props> = ({ navigation, route }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   scrollView: {
     flex: 1,
@@ -345,7 +346,7 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   form: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderRadius: 12,
     padding: 20,
   },
@@ -355,16 +356,16 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 8,
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   genderContainer: {
     flexDirection: 'row',
@@ -374,28 +375,28 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 12,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     alignItems: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   genderOptionSelected: {
-    backgroundColor: '#2196F3',
-    borderColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
+    borderColor: theme.colors.primary.electricBlue,
   },
   genderOptionText: {
     fontSize: 14,
-    color: '#333',
+    color: theme.colors.text.richBlack,
     fontWeight: '500',
   },
   genderOptionTextSelected: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
   },
   statsContainer: {
     marginTop: 20,
     paddingTop: 20,
     borderTopWidth: 1,
-    borderTopColor: '#e0e0e0',
+    borderTopColor: theme.colors.light.border,
   },
   statsRow: {
     flexDirection: 'row',
@@ -407,12 +408,12 @@ const styles = StyleSheet.create({
   statValue: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 4,
   },
   statLabel: {
     fontSize: 12,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   buttonContainer: {
     padding: 16,
@@ -423,27 +424,27 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   saveButton: {
-    backgroundColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
     padding: 16,
     borderRadius: 8,
     alignItems: 'center',
   },
   saveButtonDisabled: {
-    backgroundColor: '#ccc',
+    backgroundColor: theme.colors.text.lightGray,
   },
   saveButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },
   deleteButton: {
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     padding: 16,
     borderRadius: 8,
     alignItems: 'center',
   },
   deleteButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -462,22 +463,22 @@ const styles = StyleSheet.create({
   changePhotoButton: {
     paddingVertical: 8,
     paddingHorizontal: 16,
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     borderRadius: 6,
   },
   changePhotoButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
     fontSize: 14,
   },
   removePhotoButton: {
     paddingVertical: 8,
     paddingHorizontal: 16,
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     borderRadius: 6,
   },
   removePhotoButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
     fontSize: 14,
   },
@@ -495,22 +496,22 @@ const styles = StyleSheet.create({
   changePhotoButtonTablet: {
     paddingVertical: 10,
     paddingHorizontal: 20,
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     borderRadius: 8,
   },
   changePhotoButtonTextTablet: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
     fontSize: 16,
   },
   removePhotoButtonTablet: {
     paddingVertical: 10,
     paddingHorizontal: 20,
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     borderRadius: 8,
   },
   removePhotoButtonTextTablet: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
     fontSize: 16,
   },
@@ -522,28 +523,28 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 16,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     alignItems: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   genderOptionSelectedTablet: {
-    backgroundColor: '#2196F3',
-    borderColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
+    borderColor: theme.colors.primary.electricBlue,
   },
   genderOptionTextTablet: {
     fontSize: 16,
-    color: '#333',
+    color: theme.colors.text.richBlack,
     fontWeight: '500',
   },
   genderOptionTextSelectedTablet: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
   },
   statsContainerTablet: {
     marginTop: 24,
     paddingTop: 24,
     borderTopWidth: 1,
-    borderTopColor: '#e0e0e0',
+    borderTopColor: theme.colors.light.border,
   },
   statsRowTablet: {
     flexDirection: 'row',
@@ -555,15 +556,15 @@ const styles = StyleSheet.create({
   statValueTablet: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 6,
   },
   statLabelTablet: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   formTablet: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderRadius: 12,
     padding: 32,
     maxWidth: 600,
@@ -576,36 +577,36 @@ const styles = StyleSheet.create({
   labelTablet: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 10,
   },
   inputTablet: {
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     padding: 16,
     fontSize: 18,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   saveButtonTablet: {
-    backgroundColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
     padding: 20,
     borderRadius: 8,
     alignItems: 'center',
   },
   saveButtonTextTablet: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 18,
     fontWeight: 'bold',
   },
   deleteButtonTablet: {
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     padding: 20,
     borderRadius: 8,
     alignItems: 'center',
   },
   deleteButtonTextTablet: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 18,
     fontWeight: 'bold',
   },

--- a/src/screens/CreateTournamentScreen.tsx
+++ b/src/screens/CreateTournamentScreen.tsx
@@ -15,6 +15,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { RootStackParamList, Player, Gender, PlayerGroup } from '../types';
 import DatabaseService from '../services/DatabaseService';
 import TournamentService, { TeamCreationMode } from '../services/TournamentService';
+import { theme } from '../theme';
 
 type CreateTournamentScreenNavigationProp = StackNavigationProp<RootStackParamList, 'CreateTournament'>;
 
@@ -339,13 +340,13 @@ const CreateTournamentScreen: React.FC<Props> = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   scrollView: {
     flex: 1,
   },
   section: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     margin: 16,
     padding: 16,
     borderRadius: 12,
@@ -353,30 +354,30 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 12,
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   modeOption: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     marginBottom: 8,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   modeOptionSelected: {
-    backgroundColor: '#e3f2fd',
-    borderColor: '#2196F3',
+    backgroundColor: theme.colors.background.coolGray,
+    borderColor: theme.colors.primary.electricBlue,
   },
   modeInfo: {
     flex: 1,
@@ -384,25 +385,25 @@ const styles = StyleSheet.create({
   modeTitle: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 4,
   },
   modeTitleSelected: {
-    color: '#2196F3',
+    color: theme.colors.primary.electricBlue,
   },
   modeDescription: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   modeDescriptionSelected: {
-    color: '#1976D2',
+    color: theme.colors.primary.deepNavy,
   },
   radioButton: {
     width: 20,
     height: 20,
     borderRadius: 10,
     borderWidth: 2,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -410,21 +411,21 @@ const styles = StyleSheet.create({
     width: 10,
     height: 10,
     borderRadius: 5,
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
   },
   playerCard: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     marginBottom: 8,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   playerCardSelected: {
-    backgroundColor: '#e8f5e8',
-    borderColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
+    borderColor: theme.colors.accent.successGreen,
   },
   playerInfo: {
     flex: 1,
@@ -432,28 +433,28 @@ const styles = StyleSheet.create({
   playerName: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 2,
   },
   playerNameSelected: {
-    color: '#2E7D32',
+    color: theme.colors.accent.successGreen,
   },
   playerNickname: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     fontStyle: 'italic',
     marginBottom: 2,
   },
   playerNicknameSelected: {
-    color: '#388E3C',
+    color: theme.colors.accent.successGreen,
   },
   playerGender: {
     fontSize: 12,
-    color: '#999',
+    color: theme.colors.text.mediumGray,
     textTransform: 'capitalize',
   },
   playerGenderSelected: {
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
   },
   selectionIndicator: {
     width: 24,
@@ -463,7 +464,7 @@ const styles = StyleSheet.create({
   },
   checkmark: {
     fontSize: 18,
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
     fontWeight: 'bold',
   },
   emptyState: {
@@ -472,34 +473,34 @@ const styles = StyleSheet.create({
   },
   emptyStateText: {
     fontSize: 16,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     textAlign: 'center',
     marginBottom: 16,
   },
   addPlayersButton: {
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
   },
   addPlayersButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
   },
   buttonContainer: {
     padding: 16,
   },
   createButton: {
-    backgroundColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
     padding: 16,
     borderRadius: 8,
     alignItems: 'center',
   },
   createButtonDisabled: {
-    backgroundColor: '#ccc',
+    backgroundColor: theme.colors.text.lightGray,
   },
   createButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -517,21 +518,21 @@ const styles = StyleSheet.create({
   sectionTitleInContainer: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
   },
   groupCard: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: theme.colors.light.border,
     borderRadius: 8,
     marginBottom: 8,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
   },
   groupCardSelected: {
-    backgroundColor: '#e8f5e8',
-    borderColor: '#4CAF50',
+    backgroundColor: theme.colors.accent.successGreen,
+    borderColor: theme.colors.accent.successGreen,
   },
   groupInfo: {
     flex: 1,
@@ -539,26 +540,26 @@ const styles = StyleSheet.create({
   groupName: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 2,
   },
   groupNameSelected: {
-    color: '#2E7D32',
+    color: theme.colors.accent.successGreen,
   },
   groupPlayerCount: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   groupPlayerCountSelected: {
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
   },
   clearGroupButton: {
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     padding: 8,
     borderRadius: 8,
   },
   clearGroupButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
   },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -45,7 +45,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
         
         {/* Hero Header with Gradient */}
         <LinearGradient
-          colors={['#202123', '#343541', '#444654']}
+          colors={theme.gradients.navyGradient}
           style={styles.heroSection}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}>

--- a/src/screens/PlayerGroupsScreen.tsx
+++ b/src/screens/PlayerGroupsScreen.tsx
@@ -12,6 +12,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { useFocusEffect } from '@react-navigation/native';
 import { RootStackParamList, PlayerGroup, SerializedPlayerGroup } from '../types';
 import DatabaseService from '../services/DatabaseService';
+import { theme } from '../theme';
 
 type PlayerGroupsScreenNavigationProp = StackNavigationProp<RootStackParamList, 'PlayerGroups'>;
 
@@ -118,30 +119,30 @@ const PlayerGroupsScreen: React.FC<Props> = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   header: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     padding: 16,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderBottomWidth: 1,
-    borderBottomColor: '#e0e0e0',
+    borderBottomColor: theme.colors.light.border,
   },
   title: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
   },
   addButton: {
-    backgroundColor: '#FF9800',
+    backgroundColor: theme.colors.accent.warningOrange,
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
   },
   addButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
     fontSize: 14,
   },
@@ -149,7 +150,7 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   groupCard: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     padding: 16,
     borderRadius: 12,
     marginBottom: 12,
@@ -157,7 +158,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -171,24 +172,24 @@ const styles = StyleSheet.create({
   groupName: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 4,
   },
   playerCount: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     marginBottom: 2,
   },
   createdDate: {
     fontSize: 12,
-    color: '#999',
+    color: theme.colors.text.mediumGray,
   },
   groupActions: {
     alignItems: 'flex-end',
   },
   editText: {
     fontSize: 14,
-    color: '#2196F3',
+    color: theme.colors.primary.electricBlue,
     fontWeight: '500',
   },
   emptyState: {
@@ -199,12 +200,12 @@ const styles = StyleSheet.create({
   emptyStateTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 8,
   },
   emptyStateText: {
     fontSize: 16,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     textAlign: 'center',
     marginBottom: 24,
     paddingHorizontal: 40,

--- a/src/screens/PlayersScreen.tsx
+++ b/src/screens/PlayersScreen.tsx
@@ -137,7 +137,9 @@ const PlayersScreen: React.FC<Props> = ({ navigation }) => {
   const renderGenderLabel = (gender: string) => {
     const isMale = gender.toLowerCase() === 'male';
     const iconName = isMale ? 'human-male' : 'human-female';
-    const iconColor = isMale ? theme.colors.primary.electricBlue : '#E91E63';
+    const iconColor = isMale
+      ? theme.colors.primary.electricBlue
+      : theme.colors.accent.errorRed;
     
     return (
       <View style={styles.genderContainer}>

--- a/src/screens/TournamentHistoryScreen.tsx
+++ b/src/screens/TournamentHistoryScreen.tsx
@@ -13,6 +13,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { RootStackParamList, Tournament, TournamentStatus } from '../types';
 import DatabaseService from '../services/DatabaseService';
 import { MaterialIcons } from '@expo/vector-icons';
+import { theme } from '../theme';
 
 type TournamentHistoryNavigationProp = StackNavigationProp<RootStackParamList, 'TournamentHistory'>;
 
@@ -50,13 +51,13 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
   const getStatusColor = (status: TournamentStatus): string => {
     switch (status) {
       case TournamentStatus.COMPLETED:
-        return '#4CAF50';
+        return theme.colors.accent.successGreen';
       case TournamentStatus.ACTIVE:
-        return '#2196F3';
+        return theme.colors.primary.electricBlue';
       case TournamentStatus.SETUP:
-        return '#FF9800';
+        return theme.colors.accent.warningOrange';
       default:
-        return '#757575';
+        return theme.colors.text.darkGray';
     }
   };
 
@@ -152,16 +153,16 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
       
       <View style={styles.tournamentDetails}>
         <View style={styles.detailItem}>
-          <MaterialIcons name="groups" size={16} color="#666" />
+          <MaterialIcons name="groups" size={16} color="theme.colors.text.darkGray" />
           <Text style={styles.detailText}>Teams: {item.teams.length}</Text>
         </View>
         <View style={styles.detailItem}>
-          <MaterialIcons name="timer" size={16} color="#666" />
+          <MaterialIcons name="timer" size={16} color="theme.colors.text.darkGray" />
           <Text style={styles.detailText}>Round: {item.currentRound}</Text>
         </View>
         {item.winner && (
           <View style={styles.detailItem}>
-            <MaterialIcons name="emoji-events" size={16} color="#4CAF50" />
+            <MaterialIcons name="emoji-events" size={16} color="theme.colors.accent.successGreen" />
             <Text style={styles.winnerText}>Winner: {item.winner.teamName}</Text>
           </View>
         )}
@@ -173,7 +174,7 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
 
   const renderEmptyState = () => (
     <View style={styles.emptyState}>
-      <MaterialIcons name="history" size={64} color="#ccc" style={styles.emptyIcon} />
+      <MaterialIcons name="history" size={64} color="theme.colors.text.mediumGray" style={styles.emptyIcon} />
       <Text style={styles.emptyStateTitle}>No Tournament History</Text>
       <Text style={styles.emptyStateText}>
         Create your first tournament to see it appear here!
@@ -181,7 +182,7 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
       <TouchableOpacity
         style={styles.createButton}
         onPress={() => navigation.navigate('CreateTournament')}>
-        <MaterialIcons name="add" size={20} color="#fff" style={styles.buttonIcon} />
+        <MaterialIcons name="add" size={20} color="theme.colors.background.pureWhite" style={styles.buttonIcon} />
         <Text style={styles.createButtonText}>Create Tournament</Text>
       </TouchableOpacity>
     </View>
@@ -213,7 +214,7 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
         style={styles.devButton}
         onPress={clearAllTournaments}
         activeOpacity={0.8}>
-        <MaterialIcons name="delete" size={24} color="#fff" />
+        <MaterialIcons name="delete" size={24} color="theme.colors.background.pureWhite" />
       </TouchableOpacity>
     </SafeAreaView>
   );
@@ -222,7 +223,7 @@ const TournamentHistoryScreen: React.FC<Props> = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   loadingContainer: {
     flex: 1,
@@ -231,7 +232,7 @@ const styles = StyleSheet.create({
   },
   loadingText: {
     fontSize: 16,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   listContainer: {
     padding: 16,
@@ -242,12 +243,12 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   tournamentItem: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -264,7 +265,7 @@ const styles = StyleSheet.create({
   tournamentName: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     flex: 1,
   },
   statusContainer: {
@@ -280,7 +281,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   statusText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 12,
     fontWeight: 'bold',
   },
@@ -297,18 +298,18 @@ const styles = StyleSheet.create({
   },
   detailText: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     marginLeft: 4,
   },
   winnerText: {
     fontSize: 14,
-    color: '#4CAF50',
+    color: theme.colors.accent.successGreen,
     fontWeight: 'bold',
     marginLeft: 4,
   },
   dateText: {
     fontSize: 12,
-    color: '#999',
+    color: theme.colors.text.mediumGray,
   },
   emptyState: {
     alignItems: 'center',
@@ -320,17 +321,17 @@ const styles = StyleSheet.create({
   emptyStateTitle: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 8,
   },
   emptyStateText: {
     fontSize: 16,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     textAlign: 'center',
     marginBottom: 24,
   },
   createButton: {
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 8,
@@ -341,7 +342,7 @@ const styles = StyleSheet.create({
     marginRight: 8,
   },
   createButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -349,14 +350,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 20,
     right: 20,
-    backgroundColor: '#f44336',
+    backgroundColor: theme.colors.accent.errorRed,
     width: 56,
     height: 56,
     borderRadius: 28,
     alignItems: 'center',
     justifyContent: 'center',
     elevation: 8,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 4,

--- a/src/screens/TournamentScreen.tsx
+++ b/src/screens/TournamentScreen.tsx
@@ -15,6 +15,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { RootStackParamList, Tournament, Match, Team } from '../types';
 import DatabaseService from '../services/DatabaseService';
 import TournamentService from '../services/TournamentService';
+import { theme } from '../theme';
 
 type TournamentScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Tournament'>;
 type TournamentScreenRouteProp = RouteProp<RootStackParamList, 'Tournament'>;
@@ -258,19 +259,19 @@ const TournamentScreen: React.FC<Props> = ({ navigation, route }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
   },
   header: {
-    backgroundColor: '#f5f5f5',
+    backgroundColor: theme.colors.background.coolGray,
     padding: 16,
     gap: 12,
   },
   headerCard: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     padding: 16,
     borderRadius: 12,
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -289,21 +290,21 @@ const styles = StyleSheet.create({
   tournamentName: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 4,
   },
   statusText: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   deleteButton: {
-    backgroundColor: '#ff4757',
+    backgroundColor: theme.colors.accent.errorRed,
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
     alignItems: 'center',
     elevation: 1,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -313,26 +314,26 @@ const styles = StyleSheet.create({
   },
   deleteButtonText: {
     fontSize: 14,
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: '600',
   },
   winnerContainer: {
-    backgroundColor: '#fff3cd',
+    backgroundColor: theme.colors.background.pureWhite3cd,
     padding: 12,
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: '#ffeaa7',
+    borderColor: theme.colors.accent.warningOrange,
     alignItems: 'center',
   },
   winnerTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#856404',
+    color: theme.colors.accent.warningOrange,
     marginBottom: 4,
   },
   winnerName: {
     fontSize: 16,
-    color: '#856404',
+    color: theme.colors.accent.warningOrange,
   },
   bracketContainer: {
     flex: 1,
@@ -344,17 +345,17 @@ const styles = StyleSheet.create({
   roundTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     marginBottom: 12,
     textAlign: 'center',
   },
   matchCard: {
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: theme.colors.text.richBlack,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -363,9 +364,9 @@ const styles = StyleSheet.create({
     shadowRadius: 2.22,
   },
   matchCardComplete: {
-    backgroundColor: '#f8f9fa',
+    backgroundColor: theme.colors.background.coolGray,
     borderWidth: 1,
-    borderColor: '#28a745',
+    borderColor: theme.colors.accent.successGreen,
   },
   matchHeader: {
     flexDirection: 'row',
@@ -375,17 +376,17 @@ const styles = StyleSheet.create({
   },
   roundText: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     fontWeight: '500',
   },
   completeText: {
     fontSize: 12,
-    color: '#28a745',
+    color: theme.colors.accent.successGreen,
     fontWeight: 'bold',
   },
   byeText: {
     fontSize: 12,
-    color: '#ffc107',
+    color: theme.colors.accent.warningOrange,
     fontWeight: 'bold',
   },
   teamsContainer: {
@@ -397,39 +398,39 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 8,
     borderRadius: 6,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: theme.colors.background.coolGray,
   },
   winnerRow: {
-    backgroundColor: '#d4edda',
+    backgroundColor: theme.colors.accent.successGreen,
     borderWidth: 1,
-    borderColor: '#c3e6cb',
+    borderColor: theme.colors.accent.successGreen,
   },
   teamName: {
     fontSize: 16,
-    color: '#333',
+    color: theme.colors.text.richBlack,
     flex: 1,
   },
   winnerText: {
     fontWeight: 'bold',
-    color: '#155724',
+    color: theme.colors.accent.successGreen,
   },
   score: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: theme.colors.text.richBlack,
     minWidth: 30,
     textAlign: 'center',
   },
   footer: {
     padding: 16,
     alignItems: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background.pureWhite,
     borderTopWidth: 1,
-    borderTopColor: '#e0e0e0',
+    borderTopColor: theme.colors.light.border,
   },
   footerText: {
     fontSize: 14,
-    color: '#666',
+    color: theme.colors.text.darkGray,
   },
   loadingContainer: {
     flex: 1,
@@ -444,17 +445,17 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 18,
-    color: '#666',
+    color: theme.colors.text.darkGray,
     marginBottom: 20,
   },
   backButton: {
-    backgroundColor: '#2196F3',
+    backgroundColor: theme.colors.primary.electricBlue,
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderRadius: 8,
   },
   backButtonText: {
-    color: '#fff',
+    color: theme.colors.background.pureWhite,
     fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
## Summary
- integrate ChatGPT theme tokens throughout screens
- replace hardcoded colors with design system colors
- swap gradient constants to theme gradient
- tweak gender icon color to match theme

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408e4fb620832795e8c60bd93d30fa