### PR TITLE
Implement prize pool payouts

### DIFF
--- a/src/screens/CreateTournamentScreen.tsx
+++ b/src/screens/CreateTournamentScreen.tsx
@@ -27,6 +27,7 @@ interface Props {
 
 const CreateTournamentScreen: React.FC<Props> = ({ navigation }) => {
   const [tournamentName, setTournamentName] = useState('');
+  const [buyIn, setBuyIn] = useState('');
   const [allPlayers, setAllPlayers] = useState<Player[]>([]);
   const [selectedPlayers, setSelectedPlayers] = useState<Player[]>([]);
   const [teamMode, setTeamMode] = useState<TeamCreationMode>(TeamCreationMode.MANUAL);
@@ -125,7 +126,8 @@ const CreateTournamentScreen: React.FC<Props> = ({ navigation }) => {
       const tournamentId = await TournamentService.createTournament(
         tournamentName.trim(),
         selectedPlayers,
-        teamMode
+        teamMode,
+        parseFloat(buyIn) || 0
       );
 
       Alert.alert(
@@ -207,6 +209,16 @@ const CreateTournamentScreen: React.FC<Props> = ({ navigation }) => {
             onChangeText={setTournamentName}
             placeholder="Enter tournament name"
             autoCapitalize="words"
+          />
+        </Card>
+
+        <Card variant="outlined" padding="lg" style={styles.section}>
+          <Text style={styles.sectionTitle}>Buy In Amount</Text>
+          <TextInput
+            value={buyIn}
+            onChangeText={setBuyIn}
+            placeholder="Enter buy in amount"
+            keyboardType="numeric"
           />
         </Card>
 

--- a/src/screens/TournamentScreen.tsx
+++ b/src/screens/TournamentScreen.tsx
@@ -245,6 +245,9 @@ const TournamentScreen: React.FC<Props> = ({ navigation, route }) => {
   console.log('Tournament matches passed to getBracketStructure:', tournament.matches?.length || 0);
   const isComplete = TournamentService.isTournamentComplete(tournament.matches);
   const winner = TournamentService.getTournamentWinner(tournament.matches);
+  const runnerUp = TournamentService.getTournamentRunnerUp(tournament.matches);
+  const firstPrize = tournament.pot * 0.7;
+  const secondPrize = tournament.pot * 0.3;
 
   return (
     <SafeAreaView style={styles.container}>
@@ -273,6 +276,16 @@ const TournamentScreen: React.FC<Props> = ({ navigation, route }) => {
           <Card variant="outlined" padding="lg" style={styles.winnerContainer}>
             <Text style={styles.winnerTitle}>🏆 Champion</Text>
             <Text style={styles.winnerName}>{winner.teamName}</Text>
+            {tournament.pot > 0 && (
+              <Text style={styles.payoutText}>Wins ${firstPrize.toFixed(2)}</Text>
+            )}
+          </Card>
+        )}
+        {isComplete && runnerUp && tournament.pot > 0 && (
+          <Card variant="outlined" padding="lg" style={styles.winnerContainer}>
+            <Text style={styles.winnerTitle}>🥈 Runner Up</Text>
+            <Text style={styles.winnerName}>{runnerUp.teamName}</Text>
+            <Text style={styles.payoutText}>Wins ${secondPrize.toFixed(2)}</Text>
           </Card>
         )}
       </View>
@@ -345,6 +358,11 @@ const createStyles = (theme: Theme) =>
       ...theme.textStyles.bodyLarge,
       color: theme.colors.accent.warningOrange,
       fontWeight: theme.typography.fontWeights.semibold,
+    },
+    payoutText: {
+      ...theme.textStyles.bodySmall,
+      color: theme.colors.text.darkGray,
+      marginTop: theme.spacing.xs,
     },
     bracketContainer: {
       flex: 1,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,8 @@ export interface Tournament {
   matches: Match[];
   status: TournamentStatus;
   currentRound: number;
+  buyIn: number;
+  pot: number;
   winner?: Team;
   createdAt: Date;
   updatedAt: Date;
@@ -134,6 +136,8 @@ export interface DatabaseTournament {
   status: string;
   current_round: number;
   winner_id: string | null;
+  buy_in: number;
+  pot: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- allow entering a buy in amount when creating a tournament
- store buy in and pot in the database and via tournament service
- calculate tournament payouts (70%/30%) for winner and runner up
- display prize payouts when the tournament is complete

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425cdab25c8327b6a75e0b4f21adfa